### PR TITLE
Fixing Berksfile source to point to https://supermarket.chef.io as

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -1,4 +1,4 @@
-source 'http://supermarket.getchef.io'
+source 'https://supermarket.chef.io'
 
 metadata
 cookbook 'weblogic-server-10-3-6', path: 'test/fixtures/cookbooks/weblogic-server/10-3-6'


### PR DESCRIPTION
the current http://supermarket.getchef.io causes an HTTP 301 error.