### PR TITLE
silent file owned by incorrect user

### DIFF
--- a/resources/weblogic.rb
+++ b/resources/weblogic.rb
@@ -132,7 +132,7 @@ action :create do
 
   template silent_path do
     mode 00644
-    owner owner
+    owner ownername
     group groupname
     source silent_file + '.erb'
     cookbook 'weblogic'


### PR DESCRIPTION
Looks like a typo in the resource.