### PR TITLE
Do not clober group membership

### DIFF
--- a/resources/weblogic.rb
+++ b/resources/weblogic.rb
@@ -92,7 +92,9 @@ action :create do
   node.default['java']['oracle']['accept_oracle_download_terms'] = true
   include_recipe 'java'
 
-  group groupname
+  group groupname do
+    append true
+  end
 
   user ownername do
     gid groupname


### PR DESCRIPTION
The `group` inside the `weblogic` resource clobbers group members. It replaces the list of members with an empty set. `oracle-inventory::default` then appends a user which results in the group resource _always_ running in both locations on every chef run.

```
  * weblogic[12.1.3.0.0] action create
    * group[weblogic_admin] action create
      - alter group weblogic_admin
      - replace group members with new list of members
    * linux_user[weblogic] action create (up to date)
  Recipe: oracle-inventory::default
    * group[weblogic_admin] action create (up to date)
    * linux_user[weblogic] action create (up to date)
    * directory[/ortlapp/inventory] action create (up to date)
    * template[/ortlapp/oraInst.loc] action create (up to date)
    * group[weblogic_admin] action create
      - alter group weblogic_admin
      - add missing member(s): weblogic
    * directory[/var/cache/chef/weblogic] action create (up to date)
    * directory[/ortlapp/middleware] action create (up to date)
    * remote_file[/var/cache/chef/weblogic/fmw_12.1.3.0.0_wls.jar] action create (up to date)
    * template[/var/cache/chef/weblogic/silent.rsp] action create (up to date)
    * execute[install weblogic server 12.1.3.0.0] action run (skipped due to only_if)
```

This change permits current membership whilst ensuring the group exists. Group membership should not matter, group is only used for gid on user.
```
  * weblogic[12.1.3.0.0] action create
    * group[weblogic_admin] action create (up to date)
    * linux_user[weblogic] action create (up to date)
  Recipe: oracle-inventory::default
    * group[weblogic_admin] action create (up to date)
    * linux_user[weblogic] action create (up to date)
    * directory[/ortlapp/inventory] action create (up to date)
    * template[/ortlapp/oraInst.loc] action create (up to date)
    * group[weblogic_admin] action create (up to date)
    * directory[/var/cache/chef/weblogic] action create (up to date)
    * directory[/ortlapp/middleware] action create (up to date)
    * remote_file[/var/cache/chef/weblogic/fmw_12.1.3.0.0_wls.jar] action create (up to date)
    * template[/var/cache/chef/weblogic/silent.rsp] action create (up to date)
    * execute[install weblogic server 12.1.3.0.0] action run (skipped due to only_if)
```